### PR TITLE
Fix windowed mode always being borderless

### DIFF
--- a/pathos/sources/codesrc/engine/window.cpp
+++ b/pathos/sources/codesrc/engine/window.cpp
@@ -167,7 +167,7 @@ bool CWindow::Init( void )
 	if(m_bFullScreen)
 		windowFlags |= SDL_WINDOW_FULLSCREEN;
 
-	if(Sys_CheckLaunchArgs("-borderless"))
+	if(Sys_CheckLaunchArgs("-borderless") != -1)
 		windowFlags |= SDL_WINDOW_BORDERLESS;
 
 	Int32 xPos;


### PR DESCRIPTION
Sys_CheckLaunchArgs() returns the index of the item it finds as a launch argument, and defaults to -1, which gets interpreted as True. Ironically this meant if -borderless is the first argument, the window will have a border.