### PR TITLE
Rendermode Extensions

### DIFF
--- a/pathos/pathos_jack.fgd
+++ b/pathos/pathos_jack.fgd
@@ -151,14 +151,14 @@
   [
     0: "Normal"
     1: "Color"
-    257: "Lit Color"
     2: "Texture"
-    258: "Lit Texture"
     3: "Glow"
     4: "Solid"
-    516: "Unlit Solid"
     5: "Additive"
+	257: "Lit Color"
+	258: "Lit Texture"
     261: "Lit Additive"  
+	516: "Unlit Solid"
   ]
   renderamt(integer) : "FX Amount (1 - 255)"
   rendercolor(color255) : "FX Color (R G B)" : "0 0 0"

--- a/pathos/pathos_jack.fgd
+++ b/pathos/pathos_jack.fgd
@@ -151,10 +151,14 @@
   [
     0: "Normal"
     1: "Color"
+    257: "Lit Color"
     2: "Texture"
+    258: "Lit Texture"
     3: "Glow"
     4: "Solid"
+    516: "Unlit Solid"
     5: "Additive"
+    261: "Lit Additive"  
   ]
   renderamt(integer) : "FX Amount (1 - 255)"
   rendercolor(color255) : "FX Color (R G B)" : "0 0 0"

--- a/pathos/scripts/shaders/bsprenderer.bss
+++ b/pathos/scripts/shaders/bsprenderer.bss
@@ -684,11 +684,11 @@ void main()
 	$end
 	$branch shadertype == 3
 	$begin
-		finalColor = texture2D(baselightmap, ps_lmapcoord);
+		finalColor = texture2D(baselightmap, ps_lmapcoord) * color;
 	$end
 	$branch shadertype == 4
 	$begin
-		finalColor = texture2D(maintexture, ps_texcoord);
+		finalColor = texture2D(maintexture, ps_texcoord) * color;
 	$end
 	$branch shadertype == 5 || shadertype == 6
 	$begin

--- a/pathos/sources/codesrc/common/r_common.cpp
+++ b/pathos/sources/codesrc/common/r_common.cpp
@@ -198,6 +198,7 @@ bool R_IsEntityRotated( const cl_entity_t& entity )
 //=============================================
 bool R_IsEntityTransparent( const cl_entity_t& entity, bool ignoreVBMFlags )
 {
+	// Do not & with 255 since RENDER_TRANSALPHA_UNLIT needs to be rendered differently.
 	if(entity.curstate.rendermode != RENDER_NORMAL
 		&& entity.curstate.rendermode != RENDER_TRANSALPHA)
 		return true;

--- a/pathos/sources/codesrc/engine/client/cl_tempentities.cpp
+++ b/pathos/sources/codesrc/engine/client/cl_tempentities.cpp
@@ -263,7 +263,7 @@ void CTempEntityManager::UpdateTempEntities( void )
 			if(pnext->flags & TE_FL_FADEOUT)
 			{
 				if(pnext->entity.curstate.rendermode == RENDER_NORMAL)
-					pnext->entity.curstate.rendermode = RENDER_TRANSTEXTURE;
+					pnext->entity.curstate.rendermode = RENDER_TRANSTEXTURE_LIT;
 
 				// Calculate alpha value
 				Float life = pnext->die - cls.cl_time;
@@ -701,7 +701,7 @@ void CTempEntityManager::CreateBreakModel( const Vector& origin, const Vector& s
 
 		if(sound == TE_BOUNCE_GLASS)
 		{
-			ptemp->entity.curstate.rendermode = RENDER_TRANSTEXTURE;
+			ptemp->entity.curstate.rendermode = RENDER_TRANSTEXTURE_LIT;
 			ptemp->entity.curstate.renderamt = Common::RandomFloat(120, 160);
 		}
 		else
@@ -1012,7 +1012,7 @@ void CTempEntityManager::CreateSphereModel( const Vector& origin, Float speed, F
 
 		if(sound == TE_BOUNCE_GLASS)
 		{
-			ptemp->entity.curstate.rendermode = RENDER_TRANSTEXTURE;
+			ptemp->entity.curstate.rendermode = RENDER_TRANSTEXTURE_LIT;
 			ptemp->entity.curstate.renderamt = Common::RandomFloat(120, 160);
 			ptemp->startrenderamt = ptemp->entity.curstate.renderamt;
 		}

--- a/pathos/sources/codesrc/engine/renderer/r_vbm.cpp
+++ b/pathos/sources/codesrc/engine/renderer/r_vbm.cpp
@@ -1423,7 +1423,7 @@ void CVBMRenderer::SetupLighting ( void )
 				m_pCurrentEntity->curstate.groundent != WORLDSPAWN_ENTITY_INDEX
 				&& !(m_pCurrentEntity->curstate.effects & EF_ALTLIGHTORIGIN)
 				&& (m_pCurrentEntity->curstate.rendermode == RENDER_NORMAL
-				|| m_pCurrentEntity->curstate.rendermode == RENDER_TRANSALPHA
+				|| (m_pCurrentEntity->curstate.rendermode & 255) == RENDER_TRANSALPHA
 				|| m_pCurrentEntity->curstate.renderamt > 0))
 			{
 				cl_entity_t* pentity = CL_GetEntityByIndex(m_pCurrentEntity->curstate.groundent);
@@ -2161,7 +2161,7 @@ bool CVBMRenderer::Render( void )
 		m_useBlending = true;
 	}
 
-	if ( m_pCurrentEntity->curstate.rendermode == RENDER_TRANSALPHA || m_pCurrentEntity->curstate.rendermode == RENDER_TRANSTEXTURE )
+	if ( (m_pCurrentEntity->curstate.rendermode & 255) == RENDER_TRANSALPHA || (m_pCurrentEntity->curstate.rendermode & 255) == RENDER_TRANSTEXTURE )
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -5759,8 +5759,8 @@ bool CVBMRenderer::DrawLightVectors( void )
 			if(m_pCurrentEntity->curstate.groundent != NO_ENTITY_INDEX && 
 				m_pCurrentEntity->curstate.groundent != WORLDSPAWN_ENTITY_INDEX
 				&& !(m_pCurrentEntity->curstate.effects & EF_ALTLIGHTORIGIN)
-				&& (m_pCurrentEntity->curstate.rendermode == RENDER_NORMAL
-				|| m_pCurrentEntity->curstate.rendermode == RENDER_TRANSALPHA
+				&& ((m_pCurrentEntity->curstate.rendermode & 255) == RENDER_NORMAL
+				|| (m_pCurrentEntity->curstate.rendermode & 255) == RENDER_TRANSALPHA
 				|| m_pCurrentEntity->curstate.renderamt > 0))
 			{
 				cl_entity_t* pentity = CL_GetEntityByIndex(m_pCurrentEntity->curstate.groundent);

--- a/pathos/sources/codesrc/gamedll/ai_basenpc.cpp
+++ b/pathos/sources/codesrc/gamedll/ai_basenpc.cpp
@@ -3267,7 +3267,7 @@ Uint64 CBaseNPC::GetNPCVisibilityBits( CBaseEntity* pEntity, bool checkGlass )
 			CBaseEntity* pHitEntity = CBaseEntity::GetClass(pedict);
 
 			rendermode_t renderMode = pHitEntity->GetRenderMode();
-			if(renderMode != RENDER_NORMAL && renderMode != RENDER_TRANSCOLOR)
+			if(renderMode != RENDER_NORMAL && (renderMode & 255) != RENDER_TRANSCOLOR)
 				Util::TraceLine(tr.endpos, otherEyePosition, true, false, true, false, pedict, tr);
 		}
 
@@ -3309,7 +3309,7 @@ Uint64 CBaseNPC::GetNPCVisibilityBits( CBaseEntity* pEntity, bool checkGlass )
 				CBaseEntity* pHitEntity = CBaseEntity::GetClass(pedict);
 
 				rendermode_t renderMode = pHitEntity->GetRenderMode();
-				if(renderMode != RENDER_NORMAL && renderMode != RENDER_TRANSCOLOR)
+				if(renderMode != RENDER_NORMAL && (renderMode & 255) != RENDER_TRANSCOLOR)
 					Util::TraceLine(tr.endpos, otherEyePosition, true, false, true, false, pedict, tr);
 			}
 
@@ -3349,7 +3349,7 @@ Uint64 CBaseNPC::GetNPCVisibilityBits( CBaseEntity* pEntity, bool checkGlass )
 			CBaseEntity* pHitEntity = CBaseEntity::GetClass(pedict);
 
 			rendermode_t renderMode = pHitEntity->GetRenderMode();
-			if(renderMode != RENDER_NORMAL && renderMode != RENDER_TRANSCOLOR)
+			if(renderMode != RENDER_NORMAL && (renderMode & 255) != RENDER_TRANSCOLOR)
 				Util::TraceLine(tr.endpos, otherEyePosition, true, false, true, false, pedict, tr);
 		}
 
@@ -4959,7 +4959,7 @@ bool CBaseNPC::CheckMaterialPenetration( CBaseEntity* pHitEntity, const Vector& 
 
 	CString materialName;
 	if(pHitEntity->GetRenderMode() != RENDER_NORMAL
-		&& pHitEntity->GetRenderMode() != RENDER_TRANSALPHA)
+		&& (pHitEntity->GetRenderMode() & 255) != RENDER_TRANSALPHA)
 	{
 		// All transparents are glass
 		materialName = GLASS_MATERIAL_TYPE_NAME;
@@ -5035,7 +5035,7 @@ bool CBaseNPC::IsEnemyBodyTargetShootable( CBaseEntity& enemy, bool ignoreGlass,
 
 			// Check separately for penetrable glass
 			if(!ignoreGlass && pEntity->GetRenderMode() != RENDER_NORMAL
-				&& pEntity->GetRenderMode() != RENDER_TRANSALPHA
+				&& (pEntity->GetRenderMode() & 255) != RENDER_TRANSALPHA
 				&& pEntity->GetRenderAmount() > 0)
 			{
 				Vector startPosition;

--- a/pathos/sources/codesrc/gamedll/baseentity.cpp
+++ b/pathos/sources/codesrc/gamedll/baseentity.cpp
@@ -1321,7 +1321,7 @@ void CBaseEntity::FadeBeginThink( void )
 	if(m_pState->rendermode == RENDER_NORMAL)
 	{
 		m_pState->renderamt = 255;
-		m_pState->rendermode = RENDER_TRANSTEXTURE;
+		m_pState->rendermode = RENDER_TRANSTEXTURE_LIT;
 	}
 
 	m_pState->solid = SOLID_NOT;

--- a/pathos/sources/codesrc/gamedll/funcdetail.cpp
+++ b/pathos/sources/codesrc/gamedll/funcdetail.cpp
@@ -44,11 +44,11 @@ bool CFuncDetail::Spawn( void )
 	m_pState->solid = SOLID_BSP;
 	m_pState->effects |= EF_STATICENTITY;
 
-	if(m_pState->rendermode == RENDER_NORMAL
-		|| m_pState->rendermode == RENDER_TRANSALPHA)
+	if (m_pState->rendermode == RENDER_NORMAL
+		|| (m_pState->rendermode & 255) == RENDER_TRANSALPHA)
 		m_pState->flags |= FL_WORLDBRUSH;
 
-	if(m_pState->renderamt == 0 && m_pState->rendermode == RENDER_TRANSCOLOR)
+	if(m_pState->renderamt == 0 && (m_pState->rendermode & 255) == RENDER_TRANSCOLOR)
 	{
 		m_pState->rendermode = RENDER_NORMAL;
 		m_pState->effects |= EF_COLLISION;

--- a/pathos/sources/codesrc/gamedll/funcfade.cpp
+++ b/pathos/sources/codesrc/gamedll/funcfade.cpp
@@ -44,7 +44,7 @@ bool CFuncFade::Spawn( void )
 	if(!CFuncWall::Spawn())
 		return false;
 
-	m_pState->rendermode = RENDER_TRANSTEXTURE;
+	m_pState->rendermode = RENDER_TRANSTEXTURE_LIT;
 	m_startAlpha = m_pState->renderamt;
 
 	return true;

--- a/pathos/sources/codesrc/gamedll/functrain.cpp
+++ b/pathos/sources/codesrc/gamedll/functrain.cpp
@@ -93,7 +93,7 @@ bool CFuncTrain::Spawn( void )
 	if(!m_pState->speed)
 		m_pState->speed = DEFAULT_SPEED;
 
-	if(!m_pState->renderamt && m_pState->rendermode == RENDER_TRANSCOLOR)
+	if(!m_pState->renderamt && (m_pState->rendermode & 255) == RENDER_TRANSCOLOR)
 	{
 		m_pState->rendermode = RENDER_NORMAL;
 		m_pState->effects |= EF_COLLISION;

--- a/pathos/sources/codesrc/gamedll/funcwall.cpp
+++ b/pathos/sources/codesrc/gamedll/funcwall.cpp
@@ -45,10 +45,10 @@ bool CFuncWall::Spawn( void )
 	m_pState->effects |= EF_STATICENTITY;
 
 	if(m_pState->rendermode == RENDER_NORMAL
-		|| m_pState->rendermode == RENDER_TRANSALPHA)
+		|| (m_pState->rendermode & 255) == RENDER_TRANSALPHA)
 		m_pState->flags |= FL_WORLDBRUSH;
 
-	if(m_pState->renderamt == 0 && m_pState->rendermode == RENDER_TRANSCOLOR)
+	if(m_pState->renderamt == 0 && (m_pState->rendermode & 255) == RENDER_TRANSCOLOR)
 	{
 		m_pState->rendermode = RENDER_NORMAL;
 		m_pState->effects |= EF_COLLISION;

--- a/pathos/sources/codesrc/gamedll/funcwalltoggle.cpp
+++ b/pathos/sources/codesrc/gamedll/funcwalltoggle.cpp
@@ -40,7 +40,7 @@ bool CFuncWallToggle::Spawn( void )
 	m_pState->movetype = MOVETYPE_PUSH;
 	m_pState->effects |= EF_STATICENTITY;
 
-	if(m_pState->renderamt == 0 && m_pState->rendermode == RENDER_TRANSCOLOR)
+	if(m_pState->renderamt == 0 && (m_pState->rendermode & 255) == RENDER_TRANSCOLOR)
 	{
 		m_pState->rendermode = RENDER_NORMAL;
 		m_pState->effects |= EF_COLLISION;

--- a/pathos/sources/codesrc/gamedll/game.cpp
+++ b/pathos/sources/codesrc/gamedll/game.cpp
@@ -557,8 +557,8 @@ void CreateGunshotDecal( const Vector& decalPosition,
 		return;
 
 	CString materialname;
-	if(pEntity->GetRenderMode() == RENDER_TRANSADDITIVE
-		|| pEntity->GetRenderMode() == RENDER_TRANSTEXTURE)
+	if((pEntity->GetRenderMode() & 255) == RENDER_TRANSADDITIVE
+		|| (pEntity->GetRenderMode() & 255) == RENDER_TRANSTEXTURE)
 	{
 		// Default to glass when rendermode is transparent
 		materialname = GLASS_MATERIAL_TYPE_NAME;
@@ -862,7 +862,7 @@ void FireBullets( Uint32 nbshots,
 						break;
 					}
 
-					if(pHitEntity->GetRenderMode() == RENDER_TRANSTEXTURE)
+					if((pHitEntity->GetRenderMode() & 255) == RENDER_TRANSTEXTURE)
 					{
 						// All transparents are glass
 						materialname = GLASS_MATERIAL_TYPE_NAME;

--- a/pathos/sources/codesrc/gamedll/util.cpp
+++ b/pathos/sources/codesrc/gamedll/util.cpp
@@ -1073,7 +1073,7 @@ namespace Util
 			return;
 
 		CString materialname;
-		if(pHitEntity->GetRenderMode() == RENDER_TRANSTEXTURE)
+		if((pHitEntity->GetRenderMode() & 255) == RENDER_TRANSTEXTURE)
 		{
 			// All transparents are glass
 			materialname = GLASS_MATERIAL_TYPE_NAME;

--- a/pathos/sources/codesrc/shared/entity_state.h
+++ b/pathos/sources/codesrc/shared/entity_state.h
@@ -33,7 +33,14 @@ enum rendermode_t
 	RENDER_TRANSTEXTURE,
 	RENDER_TRANSGLOW,
 	RENDER_TRANSALPHA,
-	RENDER_TRANSADDITIVE
+	RENDER_TRANSADDITIVE,
+
+	// Pathos Extensions, use (rendermode & 255) if you want to check a mode with any flags
+	RENDER_TRANSCOLOR_LIT = 257,
+	RENDER_TRANSTEXTURE_LIT,
+	RENDER_TRANSADDITIVE_LIT = 261,
+
+	RENDER_TRANSALPHA_UNLIT = 516,
 };
 
 enum solid_t


### PR DESCRIPTION
Default rendermodes now behave like GoldSrc/Half-Life, but Pathos now has new modes. 
Lit Color
Lit Texture
Lit Additive
Unlit Solid
Lit rendermodes use the lightmap with the texture. Unlit Solid renders a cutout texture with no lighting. 
Default Solid and Normal are the only rendermodes that currently allow for dynamic lighting, unlit blended rendermodes do not support detail textures.

This will change how existing maps made in Pathos render but makes it compatible with half-life style rendermode usage. All of the existing entities that use the affected rendermodes have been modified to use the appropriate version.
Effects such as brush based volumetric lights will now work again.
![image](https://github.com/TheOverfloater/pathos-public/assets/39423518/4d330014-3c74-47d6-b495-c156a09092ce)
PR is a draft since this is my first big change and it's possible there are better ways to do it. This seemed to be the simplest one.
Sadly, the rendermodes do not show up correctly in J.A.C.K. If Pathos gets a dedicated map editor or support from JACK or Trenchbroom, this could be fixed.