### PR TITLE
Fix several typos

### DIFF
--- a/docs/entity_guide.md
+++ b/docs/entity_guide.md
@@ -2386,22 +2386,22 @@ document:
    - "Passable": The door will be non-solid.
    - "Use Only": Only triggering, or using with the use key will open this door.
    
-# game_dialouge
->This entity is useful for dialouge spoken by the player character. Sounds played by this entity will then
+# game_dialogue
+>This entity is useful for dialogue spoken by the player character. Sounds played by this entity will then
 >lower the volume of other sounds, and the sound will also be save-restored on reload. This entity can also
->function as a "look at" entity, playing it's dialouge and triggering it's target when played if the player 
+>function as a "look at" entity, playing it's dialogue and triggering it's target when played if the player 
 >looks at it. If set to start off, the Look At behavior will only begin working after this entity has first
 >been triggered on by another entity.
 
  - Keyvalues:
    - "Name": Name of this entity.
    - "Target": Target entity to trigger when triggered.
-   - "WAV Name (e.g. vox/c.wav)": The wav file to use for the dialouge.
+   - "WAV Name (e.g. vox/c.wav)": The wav file to use for the dialogue.
    - "Radius": If "Look At" is set, then the entity will only play if the player is within this radius.
 
  - Spawn flags:
-   - "Look At": The entity will trigger it's dialouge automatically if looked at by the player, and if the
-   "Radius" is set, the player will need to be within the radius *and* looking at the dialouge for it to be
+   - "Look At": The entity will trigger it's dialogue automatically if looked at by the player, and if the
+   "Radius" is set, the player will need to be within the radius *and* looking at the dialogue for it to be
    triggered.
    - "Start Off": The entity's "Look at" behavior will be disabled until triggered on by another entity.
    - "Repeatable": The entity will not remove itself after being triggered, and can be re-triggered to play
@@ -2644,7 +2644,7 @@ Body of text explaining the objective<br /><br />
    - "Trigger on Entry": Target to trigger when the player enters the animation.
    - "Duration": The duration for which the player will be holding the diary in front of their face.
    - "Sound to Play": The audio file to play back while the player is holding the diary.
-   - "Player Dialouge": Player dialouge file to play at the very end. This will be cleared after the first
+   - "Player Dialogue": Player dialogue file to play at the very end. This will be cleared after the first
    use and will not play after the item_diary is used again.
    - "Type": Defines the diary model used.
      - "Benefactor": Will use the model located at "models/props/diary_benefactor.mdl".

--- a/pathos/pathos_jack.fgd
+++ b/pathos/pathos_jack.fgd
@@ -2120,7 +2120,7 @@
 // Game entities
 //
 
-@PointClass base(Targetname, Target) size(-8 -8 -8, 8 8 8) color(230 230 255) = game_dialouge : "Player's sentences" 
+@PointClass base(Targetname, Target) size(-8 -8 -8, 8 8 8) color(230 230 255) = game_dialogue : "Player's sentences" 
 [
   message(sound) : "WAV Name (e.g. vox/c.wav)"
   radius(integer) : "Radius" : 0
@@ -2266,7 +2266,7 @@
   entrytarget(string) : "Trigger on Entry"
   duration(integer) : "Duration" : 0
   soundfile(sound) : "Sound to Play"
-  playersound(sound) : "Player Dialouge"
+  playersound(sound) : "Player Dialogue"
   type(Choices) : "Type" : 0 =
   [
     0 : "Benefactor"

--- a/pathos/scripts/subtitles.txt
+++ b/pathos/scripts/subtitles.txt
@@ -3,9 +3,9 @@ testradio1
 Robotnik: Hello, you are listening to a radio message.
 }
 
-testdialouge1
+testdialogue1
 {
-Boss Nass: This is a piece of test dialouge.
+Boss Nass: This is a piece of test dialogue.
 }
 
 ai_flagtoggler
@@ -278,14 +278,14 @@ env_particleeffect
 I recreated Quake 1's particle effects mainly as a nostalgia thing and not as anything serious. You can test these in this room.
 }
 
-game_dialouge_lookat
+game_dialogue_lookat
 {
-game_dialouge entities can also function as "look at" entities, much like trigger_lookat. If the player is looking at them for a given amount of time without anything obstructing the view, then dialouge will play automatically. This dialouge can also trigger another entity.
+game_dialogue entities can also function as "look at" entities, much like trigger_lookat. If the player is looking at them for a given amount of time without anything obstructing the view, then dialouge will play automatically. This dialouge can also trigger another entity.
 }
 
-game_dialouge
+game_dialogue
 {
-game_dialouge is an entity that basically plays a sound as if the player was speaking themselves. This is useful if you want first-person dialouge from the player themselves playing.
+game_dialogue is an entity that basically plays a sound as if the player was speaking themselves. This is useful if you want first-person dialouge from the player themselves playing.
 }
 
 fog_blending

--- a/pathos/sources/codesrc/engine/client/cl_snd.cpp
+++ b/pathos/sources/codesrc/engine/client/cl_snd.cpp
@@ -678,7 +678,7 @@ CSoundEngine::snd_active_t* CSoundEngine::AllocSound( const Char *sample, entind
 			if(!sound.active)
 				continue;
 
-			if(sound.flags & (SND_FL_KILLME|SND_FL_RADIO|SND_FL_DIALOUGE))
+			if(sound.flags & (SND_FL_KILLME|SND_FL_RADIO|SND_FL_DIALOGUE))
 				continue;
 
 			if(sound.flags & SND_FL_MOTORBIKE && !( flags & SND_FL_MOTORBIKE ))
@@ -708,7 +708,7 @@ CSoundEngine::snd_active_t* CSoundEngine::AllocSound( const Char *sample, entind
 	for(Uint32 i = 0; i < m_activeSoundsArray.size(); i++)
 	{
 		snd_active_t& sound = m_activeSoundsArray[i];
-		if(sound.flags & (SND_FL_RADIO|SND_FL_DIALOUGE|SND_FL_MOTORBIKE|SND_FL_AMBIENT))
+		if(sound.flags & (SND_FL_RADIO|SND_FL_DIALOGUE|SND_FL_MOTORBIKE|SND_FL_AMBIENT))
 			continue;
 
 		if(sound.channel == SND_CHAN_VOICE)
@@ -1764,7 +1764,7 @@ Float CSoundEngine::CalcGain( const Vector& vieworg, snd_active_t *psound, Float
 	if(!(psound->flags & SND_FL_MENU))
 		volume *= gameVolume;
 
-	if(psound->flags & (SND_FL_DIALOUGE|SND_FL_RADIO|SND_FL_DIM_OTHERS|SND_FL_DIM_OTHERS_LIGHT))
+	if(psound->flags & (SND_FL_DIALOGUE|SND_FL_RADIO|SND_FL_DIM_OTHERS|SND_FL_DIM_OTHERS_LIGHT))
 		return volume;
 
 	if(!(psound->flags & SND_FL_2D))
@@ -1971,7 +1971,7 @@ void CSoundEngine::Update( ref_params_t *pparams )
 				flmultval = 0.1;
 				break;
 			}
-			else if(m_activeSoundsArray[i].flags & (SND_FL_DIALOUGE|SND_FL_DIM_OTHERS_LIGHT))
+			else if(m_activeSoundsArray[i].flags & (SND_FL_DIALOGUE|SND_FL_DIM_OTHERS_LIGHT))
 			{
 				flmultval = 0.5;
 				break;
@@ -1991,8 +1991,8 @@ void CSoundEngine::Update( ref_params_t *pparams )
 		if(m_isMuted && !(psound->flags & (SND_FL_MUTEIGNORE|SND_FL_MENU)))
 			psound->flags |= SND_FL_KILLME;
 
-		// Kill dialouge if we fully entered water
-		if((psound->flags & SND_FL_DIALOUGE) && pparams->waterlevel >= WATERLEVEL_FULL)
+		// Kill dialogue if we fully entered water
+		if((psound->flags & SND_FL_DIALOGUE) && pparams->waterlevel >= WATERLEVEL_FULL)
 			psound->flags |= SND_FL_KILLME;
 
 		// Do not play game sounds if we're not ingame

--- a/pathos/sources/codesrc/engine/system.cpp
+++ b/pathos/sources/codesrc/engine/system.cpp
@@ -196,7 +196,7 @@ bool Sys_Init( CArray<CString>* argsArray )
 		return false;
 
 	// Whether to keep old save files - This needs to be registered just before the config file gets executed
-	g_pCvarKeepOldSaves = gConsole.CreateCVar(CVAR_FLOAT, FL_CV_SV_ONLY|FL_CV_SAVE, "sv_keepoldaves", "0", "Controls whether old quick/auto saves are kept.\n");
+	g_pCvarKeepOldSaves = gConsole.CreateCVar(CVAR_FLOAT, FL_CV_SV_ONLY|FL_CV_SAVE, "sv_keepoldsaves", "0", "Controls whether old quick/auto saves are kept.\n");
 
 	// Load the config before VID_Init
 	CString strExecCmd;

--- a/pathos/sources/codesrc/gamedll/baseentity.h
+++ b/pathos/sources/codesrc/gamedll/baseentity.h
@@ -688,8 +688,8 @@ public:
 	virtual daystage_t GetDayStage( void ) const { STUBWARNING; return DAYSTAGE_NORMAL; };
 	// Sets day state
 	virtual void SetDayStage( daystage_t daystage ) { STUBWARNING; };
-	// Sets dialouge duration for player
-	virtual void SetDialougeDuration( Float duration ) { STUBWARNING; }
+	// Sets dialogue duration for player
+	virtual void SetDialogueDuration( Float duration ) { STUBWARNING; }
 
 	// Set NPC awareness
 	virtual void SetNPCAwareness( Float awareness, CBaseEntity* pNPC, Float timeoutDelay, bool isLeanAwareness ) { STUBWARNING; };

--- a/pathos/sources/codesrc/gamedll/gamedialogue.cpp
+++ b/pathos/sources/codesrc/gamedll/gamedialogue.cpp
@@ -9,16 +9,16 @@ All Rights Reserved.
 
 #include "includes.h"
 #include "gd_includes.h"
-#include "gamedialouge.h"
+#include "gamedialogue.h"
 
 // Link the entity to it's class
-LINK_ENTITY_TO_CLASS(game_dialouge, CGameDialouge);
+LINK_ENTITY_TO_CLASS(game_dialogue, CGameDialogue);
 
 //=============================================
 // @brief
 //
 //=============================================
-CGameDialouge::CGameDialouge( edict_t* pedict ):
+CGameDialogue::CGameDialogue( edict_t* pedict ):
 	CPointEntity(pedict),
 	m_radius(0),
 	m_isActive(false),
@@ -31,7 +31,7 @@ CGameDialouge::CGameDialouge( edict_t* pedict ):
 // @brief
 //
 //=============================================
-CGameDialouge::~CGameDialouge( void )
+CGameDialogue::~CGameDialogue( void )
 {
 }
 
@@ -39,22 +39,22 @@ CGameDialouge::~CGameDialouge( void )
 // @brief
 //
 //=============================================
-void CGameDialouge::DeclareSaveFields( void )
+void CGameDialogue::DeclareSaveFields( void )
 {
 	// Call base class to do it first
 	CPointEntity::DeclareSaveFields();
 	
-	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialouge, m_radius, EFIELD_FLOAT));
-	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialouge, m_isActive, EFIELD_BOOLEAN));
-	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialouge, m_beginTime, EFIELD_TIME));
-	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialouge, m_duration, EFIELD_FLOAT));
+	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialogue, m_radius, EFIELD_FLOAT));
+	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialogue, m_isActive, EFIELD_BOOLEAN));
+	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialogue, m_beginTime, EFIELD_TIME));
+	DeclareSaveField(DEFINE_DATA_FIELD(CGameDialogue, m_duration, EFIELD_FLOAT));
 }
 
 //=============================================
 // @brief
 //
 //=============================================
-bool CGameDialouge::KeyValue( const keyvalue_t& kv )
+bool CGameDialogue::KeyValue( const keyvalue_t& kv )
 {
 	if(!qstrcmp(kv.keyname, "radius"))
 	{
@@ -69,7 +69,7 @@ bool CGameDialouge::KeyValue( const keyvalue_t& kv )
 // @brief
 //
 //=============================================
-bool CGameDialouge::Spawn( void )
+bool CGameDialogue::Spawn( void )
 {
 	if(m_pFields->message == NO_STRING_VALUE)
 	{
@@ -88,7 +88,7 @@ bool CGameDialouge::Spawn( void )
 
 	if(m_isActive && (m_radius || HasSpawnFlag(FL_LOOK_AT)))
 	{
-		SetThink(&CGameDialouge::DialougeThink);
+		SetThink(&CGameDialogue::DialogueThink);
 		m_pState->nextthink = g_pGameVars->time + 0.1;
 	}
 
@@ -99,7 +99,7 @@ bool CGameDialouge::Spawn( void )
 // @brief
 //
 //=============================================
-void CGameDialouge::Precache( void )
+void CGameDialogue::Precache( void )
 {
 	if(m_pFields->message == NO_STRING_VALUE)
 		return;
@@ -111,14 +111,14 @@ void CGameDialouge::Precache( void )
 // @brief
 //
 //=============================================
-void CGameDialouge::CallUse( CBaseEntity* pActivator, CBaseEntity* pCaller, usemode_t useMode, Float value )
+void CGameDialogue::CallUse( CBaseEntity* pActivator, CBaseEntity* pCaller, usemode_t useMode, Float value )
 {
 	if(!m_isActive)
 	{
 		// Begin thinking if needed
 		if( m_radius || HasSpawnFlag(FL_LOOK_AT) )
 		{
-			SetThink( &CGameDialouge::DialougeThink );
+			SetThink( &CGameDialogue::DialogueThink );
 			m_pState->nextthink = g_pGameVars->time + 0.1;
 		}
 
@@ -135,8 +135,8 @@ void CGameDialouge::CallUse( CBaseEntity* pActivator, CBaseEntity* pCaller, usem
 		else
 			pPlayer = Util::GetHostPlayer();
 
-		Util::EmitEntitySound(pPlayer, m_pFields->message, SND_CHAN_STATIC, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOUGE);
-		pPlayer->SetDialougeDuration(m_duration);
+		Util::EmitEntitySound(pPlayer, m_pFields->message, SND_CHAN_STATIC, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOGUE);
+		pPlayer->SetDialogueDuration(m_duration);
 
 		if(!HasSpawnFlag(FL_REPEATABLE))
 		{
@@ -150,7 +150,7 @@ void CGameDialouge::CallUse( CBaseEntity* pActivator, CBaseEntity* pCaller, usem
 // @brief
 //
 //=============================================
-void CGameDialouge::DialougeThink( void )
+void CGameDialogue::DialogueThink( void )
 {
 	if(!m_radius && !HasSpawnFlag(FL_LOOK_AT))
 		return;
@@ -162,7 +162,7 @@ void CGameDialouge::DialougeThink( void )
 		float flDist = (m_pState->origin - pPlayer->GetOrigin()).Length();
 		if(flDist > m_radius)
 		{
-			SetThink( &CGameDialouge::DialougeThink );
+			SetThink( &CGameDialogue::DialogueThink );
 			m_pState->nextthink = g_pGameVars->time + 0.1;
 			return;
 		}
@@ -172,7 +172,7 @@ void CGameDialouge::DialougeThink( void )
 	{
 		if(!(pPlayer->GetFlags() & FL_ONGROUND))
 		{
-			SetThink( &CGameDialouge::DialougeThink );
+			SetThink( &CGameDialogue::DialogueThink );
 			m_pState->nextthink = g_pGameVars->time + 0.1;
 			return;
 		}
@@ -188,7 +188,7 @@ void CGameDialouge::DialougeThink( void )
 		Float dotProduct = Math::DotProduct( vecPlayerForward, vecDirToPlayer );
 		if ( dotProduct < 0.8 )
 		{
-			SetThink( &CGameDialouge::DialougeThink );
+			SetThink( &CGameDialogue::DialogueThink );
 			m_pState->nextthink = g_pGameVars->time + 0.1;
 			return;
 		}
@@ -197,15 +197,15 @@ void CGameDialouge::DialougeThink( void )
 		Util::TraceLine(playerEyes, m_pState->origin, true, false, true, pPlayer->GetEdict(), tr);
 		if(tr.fraction != 1.0)
 		{
-			SetThink( &CGameDialouge::DialougeThink );
+			SetThink( &CGameDialogue::DialogueThink );
 			m_pState->nextthink = g_pGameVars->time + 0.1;
 			return;
 		}
 	}
 
 	m_beginTime = g_pGameVars->time;
-	Util::EmitEntitySound(pPlayer, m_pFields->message, SND_CHAN_STATIC, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOUGE);
-	pPlayer->SetDialougeDuration(m_duration);
+	Util::EmitEntitySound(pPlayer, m_pFields->message, SND_CHAN_STATIC, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOGUE);
+	pPlayer->SetDialogueDuration(m_duration);
 
 	if(m_pFields->target != NO_STRING_VALUE)
 		Util::FireTargets(gd_engfuncs.pfnGetString(m_pFields->target), this, this, USE_TOGGLE, 0);
@@ -218,7 +218,7 @@ void CGameDialouge::DialougeThink( void )
 // @brief
 //
 //=============================================
-void CGameDialouge::SendInitMessage( const CBaseEntity* pPlayer )
+void CGameDialogue::SendInitMessage( const CBaseEntity* pPlayer )
 {
 	if(!m_beginTime)
 		return;
@@ -230,28 +230,28 @@ void CGameDialouge::SendInitMessage( const CBaseEntity* pPlayer )
 	}
 
 	const Char* pstrFilepath = gd_engfuncs.pfnGetString(m_pFields->message);
-	gd_engfuncs.pfnPlayEntitySound(pPlayer->GetEntityIndex(), pstrFilepath, SND_FL_DIALOUGE, SND_CHAN_VOICE, VOL_NORM, ATTN_NONE, PITCH_NORM, (g_pGameVars->time - m_beginTime), pPlayer->GetClientIndex());
+	gd_engfuncs.pfnPlayEntitySound(pPlayer->GetEntityIndex(), pstrFilepath, SND_FL_DIALOGUE, SND_CHAN_VOICE, VOL_NORM, ATTN_NONE, PITCH_NORM, (g_pGameVars->time - m_beginTime), pPlayer->GetClientIndex());
 }
 
 //=============================================
 // @brief
 //
 //=============================================
-CGameDialouge* CGameDialouge::CreateDialouge( const Char* pstrPath, const Vector& origin, Float radius, bool visibleOnly )
+CGameDialogue* CGameDialogue::CreateDialogue( const Char* pstrPath, const Vector& origin, Float radius, bool visibleOnly )
 {
-	edict_t *pEntity = gd_engfuncs.pfnCreateEntity("game_dialouge");
+	edict_t *pEntity = gd_engfuncs.pfnCreateEntity("game_dialogue");
 	if(!pEntity)
 		return nullptr;
 
-	CGameDialouge *pDialouge = reinterpret_cast<CGameDialouge *>(CBaseEntity::GetClass( pEntity ));
+	CGameDialogue *pDialogue = reinterpret_cast<CGameDialogue *>(CBaseEntity::GetClass( pEntity ));
 
 	gd_engfuncs.pfnSetOrigin(pEntity, origin);
 	pEntity->fields.message = gd_engfuncs.pfnAllocString(pstrPath);
-	pDialouge->m_radius = radius;
+	pDialogue->m_radius = radius;
 
 	if(visibleOnly)
 		pEntity->state.spawnflags |= FL_LOOK_AT;
 
 	DispatchSpawn( pEntity );
-	return pDialouge;
+	return pDialogue;
 }

--- a/pathos/sources/codesrc/gamedll/gamedialogue.h
+++ b/pathos/sources/codesrc/gamedll/gamedialogue.h
@@ -7,15 +7,15 @@ All Rights Reserved.
 ===============================================
 */
 
-#ifndef GAMEDIALOUGE_H
-#define GAMEDIALOUGE_H
+#ifndef GAMEDIALOGUE_H
+#define GAMEDIALOGUE_H
 
 #include "pointentity.h"
 
 //=============================================
 //
 //=============================================
-class CGameDialouge : public CPointEntity
+class CGameDialogue : public CPointEntity
 {
 public:
 	enum
@@ -26,8 +26,8 @@ public:
 	};
 
 public:
-	explicit CGameDialouge( edict_t* pedict );
-	virtual ~CGameDialouge( void );
+	explicit CGameDialogue( edict_t* pedict );
+	virtual ~CGameDialogue( void );
 
 public:
 	virtual bool Spawn( void ) override;
@@ -38,10 +38,10 @@ public:
 	virtual void SendInitMessage( const CBaseEntity* pPlayer ) override;
 
 public:
-	void EXPORTFN DialougeThink( void );
+	void EXPORTFN DialogueThink( void );
 
 public:
-	static CGameDialouge* CreateDialouge( const Char* pstrPath, const Vector& origin, Float radius, bool visibleOnly );
+	static CGameDialogue* CreateDialogue( const Char* pstrPath, const Vector& origin, Float radius, bool visibleOnly );
 
 private:
 	Float m_radius;
@@ -50,4 +50,4 @@ private:
 	Float m_duration;
 };
 
-#endif //GAMEDIALOUGE_H
+#endif //GAMEDIALOGUE_H

--- a/pathos/sources/codesrc/gamedll/gamedll.vcxproj
+++ b/pathos/sources/codesrc/gamedll/gamedll.vcxproj
@@ -352,7 +352,7 @@
     <ClCompile Include="game.cpp" />
     <ClCompile Include="gamestaminamodifier.cpp" />
     <ClCompile Include="gametimer.cpp" />
-    <ClCompile Include="gamedialouge.cpp" />
+    <ClCompile Include="gamedialogue.cpp" />
     <ClCompile Include="gameobjective.cpp" />
     <ClCompile Include="gamesetdaystage.cpp" />
     <ClCompile Include="gametext.cpp" />
@@ -664,7 +664,7 @@
     <ClInclude Include="funcwater.h" />
     <ClInclude Include="funcfriction.h" />
     <ClInclude Include="game.h" />
-    <ClInclude Include="gamedialouge.h" />
+    <ClInclude Include="gamedialogue.h" />
     <ClInclude Include="gamesetdaystage.h" />
     <ClInclude Include="gametext.h" />
     <ClInclude Include="gametitle.h" />

--- a/pathos/sources/codesrc/gamedll/gamedll.vcxproj.filters
+++ b/pathos/sources/codesrc/gamedll/gamedll.vcxproj.filters
@@ -267,7 +267,7 @@
     <ClCompile Include="funcwall.cpp">
       <Filter>Source Files\entities\func</Filter>
     </ClCompile>
-    <ClCompile Include="gamedialouge.cpp">
+    <ClCompile Include="gamedialogue.cpp">
       <Filter>Source Files\entities\game</Filter>
     </ClCompile>
     <ClCompile Include="gameradio.cpp">
@@ -1133,7 +1133,7 @@
     <ClInclude Include="funcwall.h">
       <Filter>Header Files\entities\func</Filter>
     </ClInclude>
-    <ClInclude Include="gamedialouge.h">
+    <ClInclude Include="gamedialogue.h">
       <Filter>Header Files\entities\game</Filter>
     </ClInclude>
     <ClInclude Include="gameradio.h">

--- a/pathos/sources/codesrc/gamedll/itemdiary.cpp
+++ b/pathos/sources/codesrc/gamedll/itemdiary.cpp
@@ -137,7 +137,7 @@ void CItemDiary::Precache( void )
 void CItemDiary::SendInitMessage( const CBaseEntity* pPlayer )
 {
 	if(m_state == DIARY_PLAYBACK && m_pPlayer && pPlayer == m_pPlayer)
-		Util::EmitEntitySound(m_pPlayer, m_soundFile, SND_CHAN_VOICE, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOUGE, pPlayer);
+		Util::EmitEntitySound(m_pPlayer, m_soundFile, SND_CHAN_VOICE, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOGUE, pPlayer);
 	
 	if(!m_isDisabled)
 		Util::EmitEntitySound(this, "items/diary_noise.wav", SND_CHAN_STATIC, (m_state == DIARY_PLAYBACK) ? 0.4 : VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_NONE, pPlayer);
@@ -265,7 +265,7 @@ void CItemDiary::AdvanceState( void )
 		// So player can cancel
 		m_pPlayer->BeginDiaryPlayback(gd_engfuncs.pfnGetString(m_soundFile), m_duration, this);
 		// Playback the sound for the player
-		Util::EmitEntitySound(m_pPlayer, m_soundFile, SND_CHAN_VOICE, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOUGE);
+		Util::EmitEntitySound(m_pPlayer, m_soundFile, SND_CHAN_VOICE, VOL_NORM, ATTN_NORM, PITCH_NORM, SND_FL_DIALOGUE);
 
 		SetThink(&CItemDiary::Exit);
 		m_pState->nextthink = g_pGameVars->time + m_duration+0.5;

--- a/pathos/sources/codesrc/gamedll/itemmotorbike.cpp
+++ b/pathos/sources/codesrc/gamedll/itemmotorbike.cpp
@@ -11,7 +11,7 @@ All Rights Reserved.
 #include "gd_includes.h"
 #include "itemmotorbike.h"
 #include "envdlight.h"
-#include "gamedialouge.h"
+#include "gamedialogue.h"
 #include "player.h"
 
 // Trashed bike animation name

--- a/pathos/sources/codesrc/gamedll/player.cpp
+++ b/pathos/sources/codesrc/gamedll/player.cpp
@@ -545,7 +545,7 @@ CPlayerEntity::CPlayerEntity( edict_t* pedict ):
 	m_lastWaterDamage(0),
 	m_nextSwimSoundTime(0),
 	m_prevWaterLevel(WATERLEVEL_NONE),
-	m_dialougePlaybackTime(0),
+	m_dialoguePlaybackTime(0),
 	m_tapeTrackFile(NO_STRING_VALUE),
 	m_tapeTrackPlayBeginTime(0),
 	m_tapeTrackDuration(0),
@@ -691,7 +691,7 @@ void CPlayerEntity::DeclareSaveFields( void )
 	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_countdownTimerTitle, EFIELD_STRING));
 	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_delayedGlobalTriggerTime, EFIELD_TIME));
 	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_delayedGlobalTriggerTarget, EFIELD_STRING));
-	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_dialougePlaybackTime, EFIELD_TIME));
+	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_dialoguePlaybackTime, EFIELD_TIME));
 	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_sprintStaminaDrainMultiplier, EFIELD_FLOAT));
 	DeclareSaveField(DEFINE_DATA_FIELD(CPlayerEntity, m_normalMovementStaminaDrainFactor, EFIELD_FLOAT));
 
@@ -6579,12 +6579,12 @@ void CPlayerEntity::TapePlaybackThink( void )
 }
 
 //=============================================
-// @brief Sets dialouge duration for player
+// @brief Sets dialogue duration for player
 //
 //=============================================
-void CPlayerEntity::SetDialougeDuration( Float duration )
+void CPlayerEntity::SetDialogueDuration( Float duration )
 {
-	m_dialougePlaybackTime = g_pGameVars->time + duration;
+	m_dialoguePlaybackTime = g_pGameVars->time + duration;
 }
 
 //=============================================

--- a/pathos/sources/codesrc/gamedll/player.h
+++ b/pathos/sources/codesrc/gamedll/player.h
@@ -308,8 +308,8 @@ public:
 	// Sets nightstage state
 	virtual void SetDayStage( daystage_t daystage ) override;
 
-	// Sets dialouge duration for player
-	virtual void SetDialougeDuration( Float duration ) override;
+	// Sets dialogue duration for player
+	virtual void SetDialogueDuration( Float duration ) override;
 
 	// Adds a medkit to the player
 	virtual bool AddMedkit( const Char* pstrClassname, bool noNotice ) override;
@@ -958,8 +958,8 @@ private:
 	// Last time we were hurt by time based dmg
 	Double						m_lastTimeBasedDmgTime[NUM_TIMEBASED_DMG];
 
-	// Dialouge playback timer
-	Double						m_dialougePlaybackTime;
+	// Dialogue playback timer
+	Double						m_dialoguePlaybackTime;
 
 private:
 	// Music playback info

--- a/pathos/sources/codesrc/shared/snd_shared.h
+++ b/pathos/sources/codesrc/shared/snd_shared.h
@@ -56,7 +56,7 @@ enum snd_flags_t
 	SND_FL_REVERBLESS		= (1<<10),
 	SND_FL_MOTORBIKE		= (1<<11),
 	SND_FL_MUTEIGNORE		= (1<<12),
-	SND_FL_DIALOUGE			= (1<<13),
+	SND_FL_DIALOGUE			= (1<<13),
 	SND_FL_RADIUS			= (1<<14),
 	SND_FL_DIM_OTHERS		= (1<<15),
 	SND_FL_SUB_ONLY_RADIUS	= (1<<16),


### PR DESCRIPTION
This PR fixes two typos, the first one being the `sv_keepoldsaves` CVAR (the "s" in "saves" was missing).

The second one being `game_dialouge` instead of `game_dialogue`. Be advised, existing maps using this entity will need to be updated to have the correct entity class name. The subtitles entries from the test/showcase maps have also been updated.