### PR TITLE
Replace ugly/workaround SDL2 library loading mechanism

### DIFF
--- a/pathos/sources/codesrc/engine/dllexports.cpp
+++ b/pathos/sources/codesrc/engine/dllexports.cpp
@@ -27,14 +27,15 @@ extern Int32 Rva2Offset( Uint32 rva, Uint32 numSections, sectionheader_t* pSecti
 //=============================================
 Int32 Rva2Offset( Uint32 rva, Uint32 numSections, sectionheader_t* pSections ) 
 {
-    Int32 i = 0;
-    for (; i < numSections; i++) {
-        Uint32 x = pSections[i].VirtualAddress + pSections[i].SizeOfRawData;
+	Int32 i = 0;
+	for (; i < numSections; i++)
+	{
+		Uint32 x = pSections[i].VirtualAddress + pSections[i].SizeOfRawData;
 
-        if (x >= rva)
-            return pSections[i].PointerToRawData + (rva + pSections[i].SizeOfRawData) - x;
-    }
-    return -1;
+		if (x >= rva)
+			return pSections[i].PointerToRawData + (rva + pSections[i].SizeOfRawData) - x;
+	}
+	return -1;
 }
 
 //=============================================
@@ -45,110 +46,110 @@ Int32 Rva2Offset( Uint32 rva, Uint32 numSections, sectionheader_t* pSections )
 //=============================================
 bool EnumExportedFunctions ( const Char *szFilename, void (*pfnCallBack)(Char*) ) 
 {
-    FILE *hFile = fopen (szFilename, "rb");
-	if(!hFile)
+	FILE *hFile = fopen (szFilename, "rb");
+	if (!hFile)
 		return false;
 
 	sectionheader_t *pSections;
 	Uint32 numSections = 0;
 
-    if (fgetc (hFile) != 'M' || fgetc (hFile) != 'Z')
+	if (fgetc (hFile) != 'M' || fgetc (hFile) != 'Z')
 	{
 		fclose(hFile);
 		return false;
 	}
 
-    Uint32 e_lfanew = 0;
-    Uint32 numberOfRvaAndSizes = 0;
-    Uint32 exportVirtualAddress = 0;
-    Uint32 exportSize = 0;
-    Int32 i = 0;
+	Uint32 e_lfanew = 0;
+	Uint32 numberOfRvaAndSizes = 0;
+	Uint32 exportVirtualAddress = 0;
+	Uint32 exportSize = 0;
+	Int32 i = 0;
 
-    fseek(hFile, 0x3C, SEEK_SET);
-    fread(&e_lfanew, 4, 1, hFile);
-    fseek(hFile, e_lfanew + 6, SEEK_SET);
-    fread(&numSections, 2, 1, hFile);
-    fseek(hFile, 108, SEEK_CUR);
-    fread(&numberOfRvaAndSizes, 4, 1, hFile);
+	fseek(hFile, 0x3C, SEEK_SET);
+	fread(&e_lfanew, 4, 1, hFile);
+	fseek(hFile, e_lfanew + 6, SEEK_SET);
+	fread(&numSections, 2, 1, hFile);
+	fseek(hFile, 108, SEEK_CUR);
+	fread(&numberOfRvaAndSizes, 4, 1, hFile);
 
-    if (numberOfRvaAndSizes != 16) 
+	if (numberOfRvaAndSizes != 16) 
 	{
 		fclose(hFile);
 		return false;
 	}
 
-    fread (&exportVirtualAddress, 4, 1, hFile);
-    fread (&exportSize, 4, 1, hFile);
+	fread (&exportVirtualAddress, 4, 1, hFile);
+	fread (&exportSize, 4, 1, hFile);
 
-    if (exportVirtualAddress <= 0 || exportSize <= 0)
-	{
-		fclose(hFile);
-		return false;
-	}
-	
-    fseek (hFile, 120, SEEK_CUR);
-
-    if (numSections <= 0)
+	if (exportVirtualAddress <= 0 || exportSize <= 0)
 	{
 		fclose(hFile);
 		return false;
 	}
 
-    pSections = static_cast<sectionheader_t *>(malloc(numSections * sizeof(sectionheader_t)));
+	fseek (hFile, 120, SEEK_CUR);
 
-    for (i = 0; i < numSections; i++) 
+	if (numSections <= 0)
 	{
-        fread(pSections[i].Name, 8, 1, hFile);
-        fread(&pSections[i].VirtualSize, 4, 1, hFile);
-        fread(&pSections[i].VirtualAddress, 4, 1, hFile);
-        fread(&pSections[i].SizeOfRawData, 4, 1, hFile);
-        fread(&pSections[i].PointerToRawData, 4, 1, hFile);
-        fread(&pSections[i].PointerToRelocations, 4, 1, hFile);
-        fread(&pSections[i].PointerToLineNumbers, 4, 1, hFile);
-        fread(&pSections[i].NumberOfRelocations, 2, 1, hFile);
-        fread(&pSections[i].NumberOfLineNumbers, 2, 1, hFile);
-        fread(&pSections[i].Characteristics, 4, 1, hFile);
-    }
+		fclose(hFile);
+		return false;
+	}
 
-    Uint32 numberOfNames = 0;
-    Uint32 addressOfNames = 0;
+	pSections = static_cast<sectionheader_t *>(malloc(numSections * sizeof(sectionheader_t)));
 
-    Int32 offset = Rva2Offset (exportVirtualAddress, numSections, pSections);
-    fseek(hFile, offset + 24, SEEK_SET);
-    fread(&numberOfNames, 4, 1, hFile);
-
-    fseek(hFile, 4, SEEK_CUR);
-    fread(&addressOfNames, 4, 1, hFile);
-
-    Int32 namesOffset = Rva2Offset (addressOfNames, numSections, pSections), pos = 0;
-    fseek(hFile, namesOffset, SEEK_SET);
-
-    for (i = 0; i < numberOfNames; i++) 
+	for (i = 0; i < numSections; i++) 
 	{
-        Int32 y = 0;
-        fread (&y, 4, 1, hFile);
-        pos = ftell (hFile);
-        fseek (hFile, Rva2Offset (y, numSections, pSections), SEEK_SET);
+		fread(pSections[i].Name, 8, 1, hFile);
+		fread(&pSections[i].VirtualSize, 4, 1, hFile);
+		fread(&pSections[i].VirtualAddress, 4, 1, hFile);
+		fread(&pSections[i].SizeOfRawData, 4, 1, hFile);
+		fread(&pSections[i].PointerToRawData, 4, 1, hFile);
+		fread(&pSections[i].PointerToRelocations, 4, 1, hFile);
+		fread(&pSections[i].PointerToLineNumbers, 4, 1, hFile);
+		fread(&pSections[i].NumberOfRelocations, 2, 1, hFile);
+		fread(&pSections[i].NumberOfLineNumbers, 2, 1, hFile);
+		fread(&pSections[i].Characteristics, 4, 1, hFile);
+	}
 
-        Char c = fgetc (hFile);
-        int szNameLen = 0;
+	Uint32 numberOfNames = 0;
+	Uint32 addressOfNames = 0;
 
-        while (c != '\0') 
+	Int32 offset = Rva2Offset (exportVirtualAddress, numSections, pSections);
+	fseek(hFile, offset + 24, SEEK_SET);
+	fread(&numberOfNames, 4, 1, hFile);
+
+	fseek(hFile, 4, SEEK_CUR);
+	fread(&addressOfNames, 4, 1, hFile);
+
+	Int32 namesOffset = Rva2Offset (addressOfNames, numSections, pSections), pos = 0;
+	fseek(hFile, namesOffset, SEEK_SET);
+
+	for (i = 0; i < numberOfNames; i++) 
+	{
+		Int32 y = 0;
+		fread (&y, 4, 1, hFile);
+		pos = ftell (hFile);
+		fseek (hFile, Rva2Offset (y, numSections, pSections), SEEK_SET);
+
+		Char c = fgetc (hFile);
+		int szNameLen = 0;
+
+		while (c != '\0') 
 		{
-            c = fgetc (hFile);
-            szNameLen++;
-        }
+			c = fgetc (hFile);
+			szNameLen++;
+		}
 
-        fseek (hFile, (-szNameLen)-1, SEEK_CUR);
-        Char* szName = static_cast<Char*>(calloc (szNameLen + 1, 1));
-        fread (szName, szNameLen, 1, hFile);
+		fseek (hFile, (-szNameLen)-1, SEEK_CUR);
+		Char* szName = static_cast<Char*>(calloc (szNameLen + 1, 1));
+		fread (szName, szNameLen, 1, hFile);
 
-        pfnCallBack (szName);
+		pfnCallBack (szName);
 
-        fseek (hFile, pos, SEEK_SET);
-    }
+		fseek (hFile, pos, SEEK_SET);
+	}
 
-    fclose (hFile);
+	fclose (hFile);
 
 	return true;
 }

--- a/pathos/sources/codesrc/engine/dllexports.h
+++ b/pathos/sources/codesrc/engine/dllexports.h
@@ -26,16 +26,16 @@ struct sectionheader_t
 			memset(Name, 0, sizeof(Name));
 		}
 
-    byte Name[8];
-    Uint32 VirtualSize;
-    Uint32 VirtualAddress;
-    Uint32 SizeOfRawData;
-    Uint32 PointerToRawData;
-    Uint32 PointerToRelocations;
-    Uint32 PointerToLineNumbers;
-    Uint16 NumberOfRelocations;
-    Uint16 NumberOfLineNumbers;
-    Uint32 Characteristics;
+	byte Name[8];
+	Uint32 VirtualSize;
+	Uint32 VirtualAddress;
+	Uint32 SizeOfRawData;
+	Uint32 PointerToRawData;
+	Uint32 PointerToRelocations;
+	Uint32 PointerToLineNumbers;
+	Uint16 NumberOfRelocations;
+	Uint16 NumberOfLineNumbers;
+	Uint32 Characteristics;
 };
 
 bool EnumExportedFunctions ( const Char *szFilename, void (*pfnCallBack)(Char*) );

--- a/pathos/sources/codesrc/engine/main.cpp
+++ b/pathos/sources/codesrc/engine/main.cpp
@@ -7,6 +7,8 @@ All Rights Reserved.
 ===============================================
 */
 
+// Required on Windows because SDL2 redirects "main" (and all Windows variants)
+// to its own before coming back here.
 #include <SDL.h>
 
 #ifdef USE_VLD
@@ -16,22 +18,25 @@ All Rights Reserved.
 #include "includes.h"
 #include "system.h"
 
-extern "C" {
-		__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-		__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 0x00000001;
-	}
+// Hint Windows to prefer discrete AMD/NVIDIA GPUs over integrated ones (mostly
+// for laptops).
+extern "C"
+{
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 0x00000001;
+}
 
 //===============================================
-// _tmain
-//
+// main
+// SDL2's Windows FAQ says the standard "main" is prefered over any Windows version.
 //===============================================
-int _tmain(Int32 argc, Char* argv[])
+int main(Int32 argc, Char* argv[])
 {
 	// Store arguments in an array
 	CArray<CString>* argsArray;
 	argsArray = new CArray<CString>();
 
-	for(Int32 i = 0; i < argc; i++)
+	for (Int32 i = 0; i < argc; i++)
 		argsArray->push_back(argv[i]);
 
 	// Run main loop

--- a/pathos/sources/codesrc/engine/pathos-engine.vcxproj
+++ b/pathos/sources/codesrc/engine/pathos-engine.vcxproj
@@ -332,6 +332,7 @@
     <ClCompile Include="system.cpp" />
     <ClCompile Include="uimanager.cpp" />
     <ClCompile Include="vid.cpp" />
+    <ClCompile Include="win32_delay_load.cpp" />
     <ClCompile Include="window.cpp" />
     <ClCompile Include=".\ui\uielements.cpp" />
     <ClCompile Include="..\shared\cvar.cpp" />

--- a/pathos/sources/codesrc/engine/pathos-engine.vcxproj.filters
+++ b/pathos/sources/codesrc/engine/pathos-engine.vcxproj.filters
@@ -423,6 +423,9 @@
     <ClCompile Include="..\shared\uischema.cpp">
       <Filter>Source Files\shared</Filter>
     </ClCompile>
+    <ClCompile Include="win32_delay_load.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="system.h">

--- a/pathos/sources/codesrc/engine/system.cpp
+++ b/pathos/sources/codesrc/engine/system.cpp
@@ -61,17 +61,6 @@ state variables and functionality.
 
 extern file_interface_t ENGINE_FILE_FUNCTIONS;
 
-// Ugly hack to manage SDL2 load before main is called
-CStartup gStartup;
-
-#ifdef _64BUILD
-// OpenAL library path
-static const Char SDL2_LIBRARY_PATH[] = "x64/SDL2.dll";
-#else
-// OpenAL library path
-static const Char SDL2_LIBRARY_PATH[] = "x86/SDL2.dll";
-#endif
-
 // Definition of engine state structure
 engine_state_t ens;
 
@@ -1186,33 +1175,4 @@ void Sys_WindowFocusLost( void )
 void Sys_WindowFocusRegained( void )
 {
 	gWindow.SetActive(true);
-}
-
-//=============================================
-// Class: CStartup
-// Function: CStartup
-//=============================================
-CStartup::CStartup( void ):
-	m_hSDL2(nullptr)
-{
-	// This entire thing exists just to be able to keep the SDL 32-bit and 64-bit libraries
-	// in separate folders.
-	m_hSDL2 = LoadLibrary(SDL2_LIBRARY_PATH);
-	if(!m_hSDL2)
-	{
-		CString str;
-		str << "Failed to load " << SDL2_LIBRARY_PATH;
-		MessageBox(nullptr, str.c_str(), "Error", MB_OK | MB_ICONERROR | MB_SETFOREGROUND);
-		exit(-1);
-	}
-}
-
-//=============================================
-// Class: CStartup
-// Function: CStartup
-//=============================================
-CStartup::~CStartup( void )
-{
-	if(m_hSDL2)
-		FreeLibrary(m_hSDL2);
 }

--- a/pathos/sources/codesrc/engine/system.h
+++ b/pathos/sources/codesrc/engine/system.h
@@ -22,23 +22,6 @@ extern CCVar* g_pCvarTimeScale;
 // Developer cvar
 extern CCVar* g_pCvarDeveloper;
 
-/*
-=================================
--Class: CConfig
--Description:
-
-=================================
-*/
-class CStartup
-{
-public:
-	CStartup();
-	~CStartup();
-
-private:
-	HMODULE m_hSDL2;
-};
-
 struct dll_export_t
 {
 	dll_export_t():

--- a/pathos/sources/codesrc/engine/win32_delay_load.cpp
+++ b/pathos/sources/codesrc/engine/win32_delay_load.cpp
@@ -1,0 +1,92 @@
+/*
+===============================================
+Pathos Engine - Created by Andrew Stephen "Overfloater" Lucas
+
+Copyright 2016
+All Rights Reserved.
+
+===============================================
+*/
+
+/*
+===============================================
+Description:
+Windows specific code to delay load the correct SDL2 DLL based on the architecture being used.
+Other libraries (like OpenAL) are handled by SDL itself so it's unnecessary to add them here.
+===============================================
+*/
+
+#define WIN32_LEAN_AND_MEAN
+#define NOGDI
+#define NOMINMAX
+#include <Windows.h>
+
+#include <delayimp.h>
+
+// Base path for libraries based on the architecture
+#ifdef _64BUILD
+#define ARCH_LIBRARY_PATH "x64"
+#else
+#define ARCH_LIBRARY_PATH "x86"
+#endif
+
+// Utility function to show error message boxes.
+// Pass "nullptr" to "szProcedure" if SDL2 is being loaded and said loading fails.
+// Or if it's already been loaded and we're trying to access a corrupted/unknown function or whatever,
+// pass its name in "szProcedure".
+static void ShowLibraryError(const char *szProcedure)
+{
+	char szBuffer[512];
+	if (szProcedure)
+		wsprintfA(szBuffer, "The procedure \"%s\" is missing from the \"SDL2.dll\" library.\n\nThe library itself could be obsolete, corrupted or too new.", szProcedure);
+	else
+		wsprintfA(szBuffer, "Failed to load the \"SDL2.dll\" library.\n\nEither it's missing or it could not be loaded.");
+
+	MessageBoxA(nullptr, szBuffer, "Fatal Error", MB_OK | MB_ICONHAND);
+}
+
+// The actual delay load mechanism.
+// Since there is no need to deal with Unicode, we can use the ANSI version of WinAPI directly.
+static FARPROC WINAPI DelayLoadNotifyHook(unsigned dliNotify, PDelayLoadInfo pdli)
+{
+	if (dliNotify != dliNotePreLoadLibrary || _stricmp(pdli->szDll, "SDL2.dll") != 0)
+		return nullptr;
+
+	HMODULE hSDL2 = LoadLibraryA(ARCH_LIBRARY_PATH "\\SDL2.dll");
+	if (!hSDL2)
+		return nullptr;
+
+	return reinterpret_cast<FARPROC>(hSDL2);
+}
+
+// The failure mechanism.
+static FARPROC WINAPI DelayLoadFailureHook(unsigned dliNotify, PDelayLoadInfo pdli)
+{
+	if (_stricmp(pdli->szDll, "SDL2.dll") != 0)
+		return nullptr;
+
+	switch (dliNotify)
+	{
+	case dliFailLoadLib:
+		// Failed to load the library (missing or corrupted)
+		ShowLibraryError(nullptr);
+		break;
+	case dliFailGetProc:
+		// Trying to access a function but said function does not exist or corrupted or something
+		ShowLibraryError(pdli->dlp.szProcName ? pdli->dlp.szProcName : "Unknown");
+		break;
+	default:
+		// No-op
+		break;
+	}
+
+	// Close the program immediately with an error exit code
+	ExitProcess(1);
+}
+
+// Tell Windows to use our mechanisms.
+extern "C"
+{
+	const PfnDliHook __pfnDliNotifyHook2 = DelayLoadNotifyHook;
+	const PfnDliHook __pfnDliFailureHook2 = DelayLoadFailureHook;
+}


### PR DESCRIPTION
This PR replaces the "ugly `CStartup` hack/workaround" to delay load the SDL2 library by Windows's built-in delay load mechanism.

Unrelated to this PR, I also replaced the usage of `_tmain` by `main` per [SDL2's Windows F.A.Q. recommendation](https://wiki.libsdl.org/SDL2/FAQWindows#i_get_undefined_reference_to_sdl_main_...).

Since OpenAL's (un)loading is handled by SDL2 itself, nothing need to be changed there.