### PR TITLE
Add windows manifest

### DIFF
--- a/pathos/sources/codesrc/engine/pathos-engine.manifest
+++ b/pathos/sources/codesrc/engine/pathos-engine.manifest
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly 
+    xmlns="urn:schemas-microsoft-com:asm.v1" 
+    xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" 
+    xmlns:compat="urn:schemas-microsoft-com:compatibility.v1" 
+    manifestVersion="1.0">
+
+    <assemblyIdentity
+        type="win32"
+        name="Pathos"
+        version="1.0.0.0"
+        processorArchitecture="*"
+    />
+
+    <description>Pathos Engine</description>
+
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+            />
+        </dependentAssembly>
+    </dependency>
+
+    <compat:compatibility>
+        <compat:application>
+            <!-- Windows 10 and 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        </compat:application>
+    </compat:compatibility>
+
+    <asmv3:trustInfo>
+        <asmv3:security>
+            <asmv3:requestedPrivileges>
+                <asmv3:requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </asmv3:requestedPrivileges>
+        </asmv3:security>
+    </asmv3:trustInfo>
+
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+            <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+
+</assembly>

--- a/pathos/sources/codesrc/engine/pathos-engine.vcxproj
+++ b/pathos/sources/codesrc/engine/pathos-engine.vcxproj
@@ -542,6 +542,9 @@
   <ItemGroup>
     <ResourceCompile Include="pathos-engine.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="pathos-engine.manifest" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/pathos/sources/codesrc/engine/pathos-engine.vcxproj.filters
+++ b/pathos/sources/codesrc/engine/pathos-engine.vcxproj.filters
@@ -985,4 +985,9 @@
       <Filter>Header Files\Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="pathos-engine.manifest">
+      <Filter>Header Files\Resource Files</Filter>
+    </Manifest>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
this is a pretty basic PR it adds manifest which enables long path aware, enables DPI aware which might prevent some issues on high res monitors
the only noticable change is it enables common controls v6 which means that error messagebox will use native windows style
example of before and after
<img width="387" height="146" alt="image" src="https://github.com/user-attachments/assets/598d2197-829c-4a69-ae50-008e4e3df77b" />
<img width="373" height="125" alt="image" src="https://github.com/user-attachments/assets/b9fc143b-9298-48f0-ac7a-48e201f97752" />
