### PR TITLE
Enable MSVC Multi core compilation

### DIFF
--- a/pathos/sources/codesrc/clientdll/client.vcxproj
+++ b/pathos/sources/codesrc/clientdll/client.vcxproj
@@ -167,6 +167,7 @@
       <AdditionalIncludeDirectories>..\common;..\libs\sdl2.0\include\;..\client;..\shared;..\shared\renderer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4244;4305</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/pathos/sources/codesrc/engine/pathos-engine.vcxproj
+++ b/pathos/sources/codesrc/engine/pathos-engine.vcxproj
@@ -207,6 +207,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>.\;..\libs\sdl2.0\include\;.\renderer\;..\common\;..\libs\;..\libs\freetype\include\;.\ui\;.\server\;.\client\;..\shared\;..\libs\enet\include;..\libs\openal\include;..\libs\detours\include;..\libs\libogg\include;..\libs\libvorbis\include;..\shared\renderer;.\windows;.\rygsdxtc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4996;4305;4244;4127;4100;4481;4512;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/pathos/sources/codesrc/gamedll/gamedll.vcxproj
+++ b/pathos/sources/codesrc/gamedll/gamedll.vcxproj
@@ -178,6 +178,7 @@
       <DisableSpecificWarnings>4996;4305;4244;4127;4100;4481;4512;4018;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/pathos/sources/codesrc/libs/libogg/win32/VS2010/libogg_static.vcxproj
+++ b/pathos/sources/codesrc/libs/libogg/win32/VS2010/libogg_static.vcxproj
@@ -155,6 +155,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <CallingConvention>Cdecl</CallingConvention>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/pathos/sources/codesrc/libs/libvorbis/win32/VS2010/libvorbis/libvorbis_static.vcxproj
+++ b/pathos/sources/codesrc/libs/libvorbis/win32/VS2010/libvorbis/libvorbis_static.vcxproj
@@ -161,6 +161,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <DisableSpecificWarnings>4244;4100;4267;4189;4305;4127;4706;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <CallingConvention>Cdecl</CallingConvention>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/pathos/sources/codesrc/libs/libvorbis/win32/VS2010/libvorbisfile/libvorbisfile_static.vcxproj
+++ b/pathos/sources/codesrc/libs/libvorbis/win32/VS2010/libvorbisfile/libvorbisfile_static.vcxproj
@@ -147,6 +147,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CallingConvention>Cdecl</CallingConvention>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Lib>
       <OutputFile>$(OutDir)$(ProjectName)_static.lib</OutputFile>

--- a/pathos/sources/codesrc/libs/sdl2.0/VisualC/SDL/SDL.vcxproj
+++ b/pathos/sources/codesrc/libs/sdl2.0/VisualC/SDL/SDL.vcxproj
@@ -226,6 +226,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <OmitDefaultLibName>true</OmitDefaultLibName>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/pathos/sources/codesrc/libs/sdl2.0/VisualC/SDLmain/SDLmain.vcxproj
+++ b/pathos/sources/codesrc/libs/sdl2.0/VisualC/SDLmain/SDLmain.vcxproj
@@ -116,6 +116,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <OmitDefaultLibName>true</OmitDefaultLibName>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/pathos/sources/codesrc/pathos-engine-public.sln
+++ b/pathos/sources/codesrc/pathos-engine-public.sln
@@ -1,6 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35506.116 d17.12
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pathos-engine", "engine\pathos-engine.vcxproj", "{9919AF58-E9C3-4694-8688-8048B97C6AC1}"
 	ProjectSection(ProjectDependencies) = postProject
 		{3A214E06-B95E-4D61-A291-1F8DF2EC10FD} = {3A214E06-B95E-4D61-A291-1F8DF2EC10FD}


### PR DESCRIPTION
ive decided to go back to using pathos but i noticed that building the engine was very slow
on my computer just this simple change dropped compile time for full rebuild from around 4 minutes to 1 min and 40 sec