### PR TITLE
Fix crash when typing 'say' in mainmenu

### DIFF
--- a/pathos/sources/codesrc/engine/commands.cpp
+++ b/pathos/sources/codesrc/engine/commands.cpp
@@ -345,8 +345,11 @@ void CCommandManager::CacheCommand( const Char* pstrCommand )
 		// handle 'say' specially
 		if(!qstrcmp(argument, "say") || !qstrcmp(argument, "say_team"))
 		{
-			m_commandArgs[m_numArgs].assign(pstr, qstrlen(pstr));
-			m_numArgs++;
+			if (pstr && pstr[0] != '\0')
+			{
+				m_commandArgs[m_numArgs].assign(pstr, qstrlen(pstr));
+				m_numArgs++;
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
Crash that happened before fix
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/e23b3903-a5f7-44fe-88b0-8772f257bd3a" />
