### PR TITLE
Fix crash when map is built with no lighting

### DIFF
--- a/pathos/sources/codesrc/engine/brushmodel.cpp
+++ b/pathos/sources/codesrc/engine/brushmodel.cpp
@@ -380,6 +380,10 @@ bool Mod_RecursiveLightPoint( const brushmodel_t* pworld, mnode_t *pnode, const 
 		dt = dt / psurf->base_samplesize;
 
 		color24_t* plightmap = psurf->psamples[SURF_LIGHTMAP_DEFAULT];
+
+		if (!plightmap)
+			continue;
+
 		plightmap += dt * ((psurf->base_extents[0] / psurf->base_samplesize)+1) + ds;
 
 		Float flIntensity = (plightmap->r + plightmap->g + plightmap->b)/3;


### PR DESCRIPTION
i built one of my maps with no lighting and randomly got this crash, adding this if check seems to have fixed it
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/bc398724-6177-42fe-89b1-468443e85dbd" />
