### PR TITLE
Implement cubemap attenuation based on brightness

### DIFF
--- a/pathos/scripts/shaders/bsprenderer.bss
+++ b/pathos/scripts/shaders/bsprenderer.bss
@@ -879,7 +879,7 @@ void main()
 		finalColor = finalColor*color;		
 		
 		if( d_cubemaps >= 1 )
-			finalColor += AddCubemaps(specularFactor);
+			finalColor.xyz += AddCubemaps(specularFactor).xyz * finalColor.xyz;
 	$end
 	// Texture unit 0 only and texunit 0 * 4
 	$branch shadertype == 3 || shadertype == 22

--- a/pathos/sources/codesrc/engine/renderer/r_bsp.cpp
+++ b/pathos/sources/codesrc/engine/renderer/r_bsp.cpp
@@ -3842,7 +3842,7 @@ bool CBSPRenderer::DrawFinal( void )
 	// Draw any cubemaps
 	if(pcubemapinfo && g_pCvarCubemaps->GetValue() > 0)
 	{
-		glBlendFunc(GL_ONE, GL_ONE);
+		glBlendFunc(GL_DST_COLOR, GL_ONE);
 
 		m_pShader->EnableAttribute(m_attribs.a_texcoord);
 		m_pShader->EnableAttribute(m_attribs.a_normal);


### PR DESCRIPTION
This fixes strong cubemaps in areas where lighting is wrong
example before and after, visible cubemap being unrealistcly bright
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/958cdba9-5b8e-44ea-bffd-7263519e8677" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9c4f3c65-6479-4ff2-8b28-32be41ecae6c" />

for multipass i modified the glblendfunc, it provides same results as singlepass but works for multipass as well
it might make cubemaps slightly darker on some maps although shouldnt break cubemaps